### PR TITLE
Adjust Dockerfile to copy/chown files in another stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM elmsln/haxcms:release-0.12.0 as haxcms
 
-FROM php:7.3-apache
-
-RUN a2enmod rewrite
-
-COPY ./services/haxcms/apache2.conf /etc/apache2/apache2.conf
-
+FROM php:7.3-apache AS files
 COPY . /var/www/html
 COPY --from=haxcms /var/www/html/build /var/www/html/build
 COPY --from=haxcms /var/www/html/dist /var/www/html/dist
 COPY --from=haxcms /var/www/html/assets/babel-top.js /var/www/html/assets/babel-top.js
 COPY --from=haxcms /var/www/html/assets/babel-bottom.js /var/www/html/assets/babel-bottom.js
 RUN chown -R www-data:www-data /var/www/html
+
+FROM php:7.3-apache
+RUN a2enmod rewrite
+
+COPY ./services/haxcms/apache2.conf /etc/apache2/apache2.conf
+COPY --from=files /var/www/html /var/www/html


### PR DESCRIPTION
Whenever a chown happens on a file, that file is technically made dirty, which means it is copied into another layer. By moving all of the copy/chown files into another stage, the final image only ships with one copy of the content.

For this particular image, I saw the following improvements pre/post build:

```cli
> docker image ls | grep haxcms
haxcms-adjusted      latest    a8ad81ccce9b     7 seconds ago       704MB
haxcms               latest    8aab098366c2     47 seconds ago      1.11GB
```

So, a reduction of 293MB in the final image. Not too bad! Enjoy! 😄 